### PR TITLE
Soundness fixes, updates, and fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared-rc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.56.0"
 
@@ -12,11 +12,12 @@ categories = ["data-structures", "memory-management", "no-std", "rust-patterns"]
 
 [features]
 std = []
-static_assertions = ["dep:static_assertions"]
 unsize = ["dep:unsize"]
 
+# deprecated, does nothing
+static_assertions = []
+
 [dependencies]
-static_assertions = { version = "1.1.0", optional = true }
 unsize = { version = "1.1.0", optional = true }
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [<img alt="github" src="https://img.shields.io/badge/github-point--rs/shared--rc-4078c0?style=for-the-badge&logo=github" height="20">](https://github.com/point-rs/shared-rc)
-[<img alt="crates.io" src="https://img.shields.io/crates/v/shared-rc.svg?style=for-the-badge&color=335a30&logo=rust" height="20">](https://crates.io/crates/shared-rc)
-[<img alt="lib.rs" src="https://img.shields.io/crates/v/shared-rc.svg?label=lib.rs&style=for-the-badge&color=282a36&logo=rust" height="20">](https://lib.rs/crates/shared-rc)
-[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-shared--rc-353535?style=for-the-badge&logo=docs.rs" height="20">](https://docs.rs/syn)
+[<img alt="lib.rs" src="https://img.shields.io/crates/v/shared-rc.svg?label=lib.rs&style=for-the-badge&color=335a30&logo=rust" height="20">](https://lib.rs/crates/shared-rc)
+[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-shared--rc-353535?style=for-the-badge&logo=docs.rs" height="20">](https://docs.rs/shared-rc)
 <!--
 [<img alt="build status" src="https://img.shields.io/github/workflow/status/point-rs/shared-rc/CI/main?style=for-the-badge" height="20">](https://github.com/point-rs/shared-rc/actions?query=branch%3Amain)
 -->


### PR DESCRIPTION
Very much a grab bag. Notable changes:

- Replaces `#[derive(Clone)]` with a manual impl which doesn't add unnecessary `Clone` bounds to `T`/`Owner`. It is now actually possible to clone `Rc<T>`. Fixes #1.
- SOUNDNESS: fixes the `Send`/`Sync` impls; previously they were written to be gated on `std::Rc<T>`'s impl, when they should be gated on `std::Rc<Owner>`'s impl (and `&T`'s).
- BREAKING: To the previous, `Arc<T>` is now `Arc<T, dyn Destruct + Send + Sync>` rather than `Arc<T, dyn Destruct>`, which is not `Send`/`Sync`.
- With the change to `Arc`'s default erased owner type, impls have been relaxed where possible to allow more owner types. Notably, where `dyn Destruct` was previously required, `dyn Destruct + Send` and `dyn Destruct + Send + Sync` are also allowed, where practical.

This is a breaking change, but the breaking change is because the previous form was unsoundly incorrect, and all breaking changes are to mitigate this. This patch is intended to be released as v0.1.1, and v0.1.0 will be yanked as unsound.